### PR TITLE
Support laravel 5.6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/contracts": "5.5.*",
-        "illuminate/support": "5.5.*"
+        "illuminate/contracts": "5.5.* || ~5.5",
+        "illuminate/support": "5.5.* || ~5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "5.*",


### PR DESCRIPTION
- liyu/signature v0.3.1 requires illuminate/support 5.5.* -> satisfiable by illuminate/support[5.5.x-dev, v5.5.0, v5.5.16, v5.5.17, v5.5.2, v5.5.28, v5.5.33, v5.5.34, v5.5.35, v5.5.36, v5.5.37, v5.5.39, v5.5.40, v5.5.41, v5.5.43].